### PR TITLE
Fix TransactionalAPI preview display overflow issue

### DIFF
--- a/src/components/TransactionalAPIPreview.astro
+++ b/src/components/TransactionalAPIPreview.astro
@@ -5,7 +5,7 @@
 <div
   class="bg-gradient-to-br from-gray-200 via-gray-200 to-primary/80 p-px rounded-lg mt-4 opacity-65"
 >
-  <div class="bg-gray-900 rounded-lg p-4 h-40 flex flex-col overflow-hidden">
+  <div class="bg-gray-900 rounded-lg p-4 min-h-40 flex flex-col overflow-hidden">
     <!-- Terminal Header -->
     <div class="flex items-center gap-2 mb-3">
       <div class="flex gap-1">


### PR DESCRIPTION
## Fix TransactionalAPI preview display overflow issue

The TransactionalAPI preview component was experiencing content overflow issues where the JSON payload in the terminal preview was being cut off.

### Changes
- Changed container height from fixed `h-40` to flexible `min-h-40` to accommodate content

This fix ensures the complete curl command with JSON payload is visible in the TransactionalAPI preview section.

Before:

<img width="441" height="250" alt="image" src="https://github.com/user-attachments/assets/a2cca14f-9d45-4d33-906a-7ab4d392cd12" />

After:

<img width="441" height="250" alt="image" src="https://github.com/user-attachments/assets/72742760-b51f-489d-8366-632f64222835" />




